### PR TITLE
Fix line splitting on windows

### DIFF
--- a/Assetic/Filter/AngularTemplateFilter.php
+++ b/Assetic/Filter/AngularTemplateFilter.php
@@ -38,7 +38,8 @@ class AngularTemplateFilter extends BaseNodeFilter
 
         $content = addslashes($asset->getContent());
         $html = '';
-        $content = explode("\n", $content);
+        // Explode by EOL
+        $content = preg_split("/\R/", $content);
         foreach ($content as $line) {
             if ($html !== '') {
                 $html .= "\n +";


### PR DESCRIPTION
Split line breaks on all operating systems (`\r\n`, `\r` and `\n` instead of just `\n`).
