### PR TITLE
Use javascript multiline strings

### DIFF
--- a/Assetic/Filter/AngularTemplateFilter.php
+++ b/Assetic/Filter/AngularTemplateFilter.php
@@ -40,15 +40,13 @@ class AngularTemplateFilter extends BaseNodeFilter
         $html = '';
         $content = explode("\n", $content);
         foreach ($content as $line) {
-            if ($html !== '') {
-                $html .= "\n +";
-            }
-            $html .= sprintf('"%s"', $line);
+            // Create javascript multiline strings
+            $html .= sprintf("%s\\\n", $line);
         }
 
         $js = <<<JS
 angular.module("$templateName", []).run(["\$templateCache", function(\$templateCache) {
-  \$templateCache.put("$templateName", $html);
+  \$templateCache.put("$templateName", "$html");
 }]);
 JS;
 


### PR DESCRIPTION
Instead of

``` js
$templateCache.put("MyBundle", ""
+ "<div id=\"sidebar-left\">"
+ "    innerText"
+ "</div>"
);
```

use

``` js
$templateCache.put("MyBundle", "\
<div id=\"sidebar-left\">\
    innerText\
</div>\
");
```

Which is more readable imho.
