### PR TITLE
Using one Module name across Bundle

### DIFF
--- a/Angular/SymfonyTemplateNameFormatter.php
+++ b/Angular/SymfonyTemplateNameFormatter.php
@@ -36,6 +36,30 @@ class SymfonyTemplateNameFormatter implements TemplateNameFormatterInterface
         $this->bundleMap = $bundleMap;
     }
 
+    /**
+     * Create module name for asset.
+     * This is bundle name.
+     *
+     * @param AssetInterface $asset
+     * @return string
+     */
+    public function getModuleForAsset(AssetInterface $asset)
+    {
+        $sourceRoot = $asset->getSourceRoot();
+        $bundleName = $this->bundleMap[$sourceRoot];
+        if (!isset($bundleName)) {
+            throw new \Exception('Could not map the asset to a bundle');
+        }
+
+        return $bundleName . '.templates';
+    }
+
+    /**
+     * Create template name for asset.
+     *
+     * @param AssetInterface $asset
+     * @return string
+     */
     public function getForAsset(AssetInterface $asset)
     {
         $sourceRoot = $asset->getSourceRoot();

--- a/Assetic/Filter/AngularTemplateFilter.php
+++ b/Assetic/Filter/AngularTemplateFilter.php
@@ -34,6 +34,7 @@ class AngularTemplateFilter extends BaseNodeFilter
 
     public function filterLoad(AssetInterface $asset)
     {
+        $moduleName = $this->templateNameFormatter->getModuleForAsset($asset);
         $templateName = $this->templateNameFormatter->getForAsset($asset);
 
         $content = addslashes($asset->getContent());
@@ -47,7 +48,7 @@ class AngularTemplateFilter extends BaseNodeFilter
         }
 
         $js = <<<JS
-angular.module("$templateName", []).run(["\$templateCache", function(\$templateCache) {
+angular.module("${moduleName}").run(["\$templateCache", function(\$templateCache) { function(\$templateCache) {
   \$templateCache.put("$templateName", $html);
 }]);
 JS;

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Just include the Angular templates as any other javascript resource using the ja
 The resulting output will be something like this:
 
 ```javascript
-angular.module("BundleName/aTemplate.html", []).run(["$templateCache", function($templateCache) {
+angular.module("BundleName.templates").run(["$templateCache", function($templateCache) {
   $templateCache.put("BundleName/aTemplate.html", "HTML here");
 }]);
-angular.module("BundleName/fooTemplate.html", []).run(["$templateCache", function($templateCache) {
+angular.module("BundleName.templates").run(["$templateCache", function($templateCache) {
   $templateCache.put("BundleName/fooTemplate.html", "HTML here");
 }]);
-angular.module("BundleName/moarTemplates/bar.html", []).run(["$templateCache", function($templateCache) {
+angular.module("BundleName.templates").run(["$templateCache", function($templateCache) {
   $templateCache.put("BundleName/moarTemplates/bar.html", "HTML here");
 }]);
 // ...


### PR DESCRIPTION
At this moment angular filter creates module for each template, and it's not possible to make sure that generated module executes before application does (unless you type all generated templates as dependencies), thus not populating $templateCache.

Solution that works for me:

1) Define bundle module in application
```js
angular.module('MyBundle', []);
```
2) Add generated file with new contents:
```js
angular.module("MyBundle.templates").run(["$templateCache", function($templateCache) {$templateCache.put("
// ...
");
```

3) Define dependency in application:
```js
angular.module('MyBundle.core', [
    // Angular modules
    'ngRoute', 
    // Templates
    'MyBundle.templates'
]);
```