### PR TITLE
Fix for unicode strings

### DIFF
--- a/Assetic/Filter/AngularTemplateFilter.php
+++ b/Assetic/Filter/AngularTemplateFilter.php
@@ -38,8 +38,8 @@ class AngularTemplateFilter extends BaseNodeFilter
 
         $content = addslashes($asset->getContent());
         $html = '';
-        // Explode by EOL
-        $content = preg_split("/\R/", $content);
+        // Explode by EOL. Keep multi-byte encoding.
+        $content = preg_split("/\R/u", $content);
         foreach ($content as $line) {
             if ($html !== '') {
                 $html .= "\n +";


### PR DESCRIPTION
Strings with multi-byte encoding become malformed when using the family of `preg_*` functions.
This can be easily fixed by adding /u modifier.

Reference: php.net: [Pattern Modifiers](http://php.net/manual/en/reference.pcre.pattern.modifiers.php).

_Another solution would be to encode string into HTML entities, but there is no guarantee that it's not using them already._